### PR TITLE
Update get_spacecraft_light_travel_time to return one-way travel time

### DIFF
--- a/src/lkspacecraft/spacecraft.py
+++ b/src/lkspacecraft/spacecraft.py
@@ -179,7 +179,7 @@ class Spacecraft(object):
         observer: string
             Observer body. Common options include "SOLAR SYSTEM BARYCENTER", "EARTH BARYCENTER", "MOON BARYCENTER"
         """
-        return self._get_state_vector(time=time, observer=observer)[1] / 2
+        return self._get_state_vector(time=time, observer=observer)[1]
 
     def get_barycentric_time_correction(
         self, time: Time, ra: Union[float, npt.NDArray], dec: Union[float, npt.NDArray]


### PR DESCRIPTION
Fixing `get_spacecraft_light_travel_time` to return one way travel time.
See figure below, a quick check of the spacecraft distance from Earth and current light travel time results in a twice the speed of light. 

![Screenshot 2025-05-20 at 11 05 16 AM](https://github.com/user-attachments/assets/7fdd4a37-f79c-45bb-855a-196ee1474637)
